### PR TITLE
Compile against CDH version of hadoop-client, mr 1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 			<dependency>
 				<groupId>org.apache.hadoop</groupId>
 				<artifactId>hadoop-client</artifactId>
-				<version>2.2.0</version>
+				<version>2.0.0-mr1-cdh4.7.0</version>
 			</dependency>
 			<dependency>
                 <groupId>org.apache.kafka</groupId>
@@ -168,6 +168,10 @@
 			<id>apache-releases</id>
 			<url>https://repository.apache.org/content/groups/public</url>
 		</repository>
+    <repository>
+      <id>cloudera</id>
+      <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+    </repository>
 	</repositories>
 
 	<build>


### PR DESCRIPTION
This enables us to run camus and camus-sweeper in our cluster
