### PR TITLE
Add time zone per portal support to PortalPartitioner

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputFormat.java
@@ -36,6 +36,7 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
     public static final String ETL_RUN_TRACKING_POST = "etl.run.tracking.post";
 
     public static final String ETL_DEFAULT_TIMEZONE = "etl.default.timezone";
+    public static final String ETL_TIMEZONES = "etl.timezones";
     public static final String ETL_DEFLATE_LEVEL = "etl.deflate.level";
     public static final String ETL_AVRO_WRITER_SYNC_INTERVAL = "etl.avro.writer.sync.interval";
     public static final String ETL_OUTPUT_FILE_TIME_PARTITION_MINS = "etl.output.file.time.partition.mins";
@@ -105,6 +106,10 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
 
     public static String getDefaultTimeZone(JobContext job) {
         return job.getConfiguration().get(ETL_DEFAULT_TIMEZONE, "America/Los_Angeles");
+    }
+
+    public static String getTimeZoneForPortal(JobContext job, String portal) {
+        return job.getConfiguration().get(ETL_TIMEZONES + "." + portal, job.getConfiguration().get(ETL_DEFAULT_TIMEZONE, "UTC"));
     }
 
     public static void setDestinationPath(JobContext job, Path dest) {

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
@@ -102,7 +102,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
         } else {
             beginTimeStamp = 0;
         }
-        
+
         ignoreServerServiceList = new HashSet<String>();
         for(String ignoreServerServiceTopic : EtlInputFormat.getEtlAuditIgnoreServiceTopicList(context))
         {
@@ -242,9 +242,9 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
                     long checksum = key.getChecksum();
                     if (checksum != messageWithKey.checksum() && checksum != messageWithoutKey.checksum()) {
                     	throw new ChecksumException("Invalid message checksum : MessageWithKey : "
-                              + messageWithKey.checksum() + " MessageWithoutKey checksum : " 
-                    		  + messageWithoutKey.checksum() 
-                    		  + ". Expected " + key.getChecksum(),	
+                              + messageWithKey.checksum() + " MessageWithoutKey checksum : "
+                    		  + messageWithoutKey.checksum()
+                    		  + ". Expected " + key.getChecksum(),
                     		  key.getOffset());
                     }
 
@@ -338,7 +338,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
             }
         }
     }
-    
+
     public void setServerService()
     {
     	if(ignoreServerServiceList.contains(key.getTopic()) || ignoreServerServiceList.contains("all"))


### PR DESCRIPTION
@ljank is my Java-foo strong enough?

Basically we have to declare portal to timezone mapping in `camus.properties` like so:

```
etl.timezones=lt:Etc/GMT-3,de:Etc/GMT-2,at:Etc/GMT-2
```

Defaults to UTC in case there's no mapping for portal (better shouldn't happen).
