### PR TITLE
Generate less small Avro files while offloading

### DIFF
--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeperETLPartitionPlanner.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeperETLPartitionPlanner.java
@@ -1,0 +1,78 @@
+package com.linkedin.camus.sweeper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormatter;
+
+import com.linkedin.camus.sweeper.utils.DateUtils;
+
+public class CamusSweeperETLPartitionPlanner extends CamusSweeperPlanner {
+    private DateTimeFormatter dayFormatter;
+    private DateTimeFormatter outputDayFormatter;
+    private DateUtils dUtils;
+
+    @Override
+    public CamusSweeperPlanner setPropertiesLogger(Properties props, Logger log) {
+        dUtils = new DateUtils(props);
+        dayFormatter = dUtils.getDateTimeFormatter("YYYY/MM/dd");
+        outputDayFormatter = dUtils.getDateTimeFormatter("'year='YYYY/'month='MM/'day'=dd");
+        return super.setPropertiesLogger(props, log);
+    }
+
+    @Override
+    public List<Properties> createSweeperJobProps(String topic, Path inputDir, Path outputDir, FileSystem fs)
+        throws IOException {
+        int daysAgo = Integer.parseInt(props.getProperty("days.ago", "0"));
+        int numDays = Integer.parseInt(props.getProperty("num.days", "15"));
+
+        DateTime midnight = dUtils.getMidnight();
+        DateTime startDate = midnight.minusDays(daysAgo);
+
+        List<Properties> jobPropsList = new ArrayList<Properties>();
+        for (int i = 0; i < numDays; ++i) {
+            Properties jobProps = new Properties(props);
+            jobProps.putAll(props);
+
+            jobProps.put("topic", topic);
+
+            DateTime currentDate = startDate.minusDays(i);
+            String directory = dayFormatter.print(currentDate);
+            String outputDirectory = outputDayFormatter.print(currentDate);
+
+            List<Path> sourcePaths = Collections.singletonList(new Path(inputDir, directory));
+            if (!fs.exists(sourcePaths.get(0))) {
+                continue;
+            }
+
+            Path destPath = new Path(outputDir, outputDirectory);
+
+            String source = sourcePaths.toString().substring(1, sourcePaths.toString().length() - 1);
+            jobProps.put("input.paths", source);
+            jobProps.put("dest.path", destPath.toString());
+
+            if (!fs.exists(destPath)) {
+                System.out.println(topic + " dest dir " + directory + " doesn't exist or . Processing.");
+                jobPropsList.add(jobProps);
+            } else if (shouldReprocess(fs, sourcePaths.get(0), destPath)) {
+                System.out.println(topic + " dest dir " + directory + " has a modified time before the source. Reprocessing.");
+
+                source = sourcePaths.toString().substring(1, sourcePaths.toString().length() - 1);
+                jobProps.put("input.paths", source);
+
+                jobPropsList.add(jobProps);
+            } else {
+                System.out.println(topic + " skipping " + directory);
+            }
+        }
+
+        return jobPropsList;
+    }
+}

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/mapreduce/AvroMorphlineKeyMapper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/mapreduce/AvroMorphlineKeyMapper.java
@@ -30,121 +30,117 @@ import com.typesafe.config.ConfigResolveOptions;
 
 public class AvroMorphlineKeyMapper extends Mapper<AvroKey<GenericRecord>, NullWritable, AvroKey<GenericRecord>, Object>
 {
-  private AvroKey<GenericRecord> outKey;
-  private AvroValue<GenericRecord> outValue;
-  private Schema keySchema;
-  private String topic;
-  private String morphlineConfiguration;
+    private AvroKey<GenericRecord> outKey;
+    private AvroValue<GenericRecord> outValue;
+    private Schema keySchema;
+    private String topic;
+    private String morphlineConfiguration;
+    private String portal;
 
-  private static final class RecordEmitter implements Command {
-    private final Mapper.Context context;
-    private final AvroKey<GenericRecord> outKey;
+    private static final class RecordEmitter implements Command {
+        private final Mapper.Context context;
+        private final AvroKey<GenericRecord> outKey;
+        private final String portal;
 
-    private RecordEmitter(Mapper.Context context, AvroKey<GenericRecord> outKey) {
-      this.context = context;
-      this.outKey = outKey;
-    }
+        private RecordEmitter(Mapper.Context context, AvroKey<GenericRecord> outKey, String portal) {
+            this.context = context;
+            this.outKey = outKey;
+            this.portal = portal;
+        }
 
-    @Override
-    public void notify(Record notification) {
-    }
+        @Override
+        public void notify(Record notification) {
+        }
 
-    @Override
-    public Command getParent() {
-      return null;
-    }
+        @Override
+        public Command getParent() {
+            return null;
+        }
 
-    @Override
-    public boolean process(Record record) {
-      GenericRecord avroRecord = (GenericRecord) record.get("_attachment_body").get(0);
-      AvroValue<GenericRecord> outValue = new AvroValue<GenericRecord>();
+        @Override
+        public boolean process(Record record) {
+            GenericRecord avroRecord = (GenericRecord) record.get("_attachment_body").get(0);
+            AvroValue<GenericRecord> outValue = new AvroValue<GenericRecord>();
 
-      try {
-        outValue.datum(avroRecord);
-        projectData(avroRecord, outKey.datum());
-        context.write(outKey, outValue);
-      } catch (Exception e) {
-        throw new RuntimeException("Cannot write record to context " + e);
-      }
-
-      return true;
-    }
-
-    private void projectData(GenericRecord source, GenericRecord target)
-    {
-      for (Field fld : target.getSchema().getFields())
-      {
-        if (fld.schema().getType() == Type.UNION)
-        {
-          Object obj = source.get(fld.name());
-          Schema sourceSchema = GenericData.get().induce(obj);
-          if (sourceSchema.getType() == Type.RECORD){
-          for (Schema type : fld.schema().getTypes()){
-            if (type.getFullName().equals(sourceSchema.getFullName())){
-              GenericRecord record = new GenericData.Record(type);
-              target.put(fld.name(), record);
-              projectData((GenericRecord) obj, record);
-              break;
+            try {
+                if (portal.equals((String) record.get("/portal").get(0))) {
+                    outValue.datum(avroRecord);
+                    projectData(avroRecord, outKey.datum());
+                    context.write(outKey, outValue);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("Cannot write record to context " + e);
             }
-          }
-          } else {
-            target.put(fld.name(), source.get(fld.name()));
-          }
-        }
-        else if (fld.schema().getType() == Type.RECORD)
-        {
-          GenericRecord record = (GenericRecord) target.get(fld.name());
 
-          if (record == null){
-            record = new GenericData.Record(fld.schema());
-            target.put(fld.name(), record);
-          }
+            return true;
+        }
 
-          projectData((GenericRecord) source.get(fld.name()), record);
+        private void projectData(GenericRecord source, GenericRecord target) {
+            for (Field fld : target.getSchema().getFields()) {
+                    if (fld.schema().getType() == Type.UNION) {
+                            Object obj = source.get(fld.name());
+                            Schema sourceSchema = GenericData.get().induce(obj);
+                            if (sourceSchema.getType() == Type.RECORD){
+                                for (Schema type : fld.schema().getTypes()){
+                                    if (type.getFullName().equals(sourceSchema.getFullName())) {
+                                        GenericRecord record = new GenericData.Record(type);
+                                        target.put(fld.name(), record);
+                                        projectData((GenericRecord) obj, record);
+                                        break;
+                                    }
+                                }
+                            } else {
+                                target.put(fld.name(), source.get(fld.name()));
+                            }
+                        } else if (fld.schema().getType() == Type.RECORD) {
+                            GenericRecord record = (GenericRecord) target.get(fld.name());
+
+                            if (record == null){
+                                record = new GenericData.Record(fld.schema());
+                                target.put(fld.name(), record);
+                            }
+
+                            projectData((GenericRecord) source.get(fld.name()), record);
+                        } else {
+                            target.put(fld.name(), source.get(fld.name()));
+                        }
+                }
         }
-        else
-        {
-          target.put(fld.name(), source.get(fld.name()));
-        }
-      }
     }
-  }
 
-  private final Record record = new Record();
-  private Command morphline;
-  private Config  morphlineConfig;
+    private final Record record = new Record();
+    private Command morphline;
+    private Config  morphlineConfig;
 
-  @Override
-  protected void setup(Context context) throws IOException,
-      InterruptedException
-  {
-    Config morphlineTopicConfig = null;
-    keySchema = AvroJob.getMapOutputKeySchema(context.getConfiguration());
-    System.out.println("output schema: " + keySchema);
-    topic = context.getConfiguration().get("camus.sweeper.morphlines.topic");
-    morphlineConfiguration = context.getConfiguration().get("camus.sweeper.morphlines.configuration");
+    @Override
+    protected void setup(Context context) throws IOException, InterruptedException {
+            Config morphlineTopicConfig = null;
+            keySchema = AvroJob.getMapOutputKeySchema(context.getConfiguration());
+            System.out.println("output schema: " + keySchema);
+            topic = context.getConfiguration().get("camus.sweeper.morphlines.topic");
+            portal = context.getConfiguration().get("portal");
+            morphlineConfiguration = context.getConfiguration().get("camus.sweeper.morphlines.configuration");
 
-    outValue = new AvroValue<GenericRecord>();
-    outKey = new AvroKey<GenericRecord>();
-    outKey.datum(new GenericData.Record(keySchema));
+            outValue = new AvroValue<GenericRecord>();
+            outKey = new AvroKey<GenericRecord>();
+            outKey.datum(new GenericData.Record(keySchema));
 
-    RecordEmitter recordEmitter = new RecordEmitter(context, outKey);
-    MorphlineContext morphlineContext = new MorphlineContext.Builder().build();
+            RecordEmitter recordEmitter = new RecordEmitter(context, outKey, portal);
+            MorphlineContext morphlineContext = new MorphlineContext.Builder().build();
 
-    morphlineConfig = ConfigFactory.parseString(morphlineConfiguration).getConfig("morphline");
+            morphlineConfig = ConfigFactory.parseString(morphlineConfiguration).getConfig("morphline");
 
-    morphline = new org.kitesdk.morphline.base.Compiler().compile(morphlineConfig, morphlineContext, recordEmitter);
-  }
-
-  @Override
-  protected void map(AvroKey<GenericRecord> key, NullWritable value, Context context) throws IOException,
-      InterruptedException
-  {
-    record.put(Fields.ATTACHMENT_BODY, key.datum());
-    if (!morphline.process(record)) {
-      // do not allow processing to continue if morphline fails
-      throw new RuntimeException("Morphline failed to process record: " + record + " with morphline config: " + morphlineConfig);
+            morphline = new org.kitesdk.morphline.base.Compiler().compile(morphlineConfig, morphlineContext, recordEmitter);
     }
-    record.removeAll(Fields.ATTACHMENT_BODY);
-  }
+
+    @Override
+    protected void map(AvroKey<GenericRecord> key, NullWritable value, Context context) throws IOException,
+    InterruptedException {
+            record.put(Fields.ATTACHMENT_BODY, key.datum());
+            if (!morphline.process(record)) {
+                // do not allow processing to continue if morphline fails
+                throw new RuntimeException("Morphline failed to process record: " + record + " with morphline config: " + morphlineConfig);
+            }
+            record.removeAll(Fields.ATTACHMENT_BODY);
+    }
 }


### PR DESCRIPTION
The idea is to use default partitioning schema (yyyy/mm/dd/HH) for events offloaded from Kafka. Then reprocess this dump for each portal individually with sweepers. We need ETL partition planner for that which will transform files in ETLed directory to hive-compatible directories.

Also: sweepers will now only include records for specific portal (condition in map task). This is necessary because data files in ETLed directory contain data for all portals.

Expected result: a lot less small files and faster processing with fewer, bigger files. Fingers crossed.

@ljank 
