### PR TITLE
Fix Sweeper executor thread shutdown

### DIFF
--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeper.java
@@ -217,8 +217,6 @@ public class CamusSweeper extends Configured implements Tool
       try
       {
         runCollectorForTopicDir(fs, topicName, new Path(topic.getPath(), sourceSubdir), destinationPath);
-        log.info("Shutting down priority executor");
-        executorService.shutdown();
       }
       catch (Exception e)
       {
@@ -227,6 +225,11 @@ public class CamusSweeper extends Configured implements Tool
         executorService.shutdown();
         throw e;
       }
+    }
+
+    if (!executorService.isTerminated()) {
+      log.info("Shutting down priority executor");
+      executorService.shutdown();
     }
 
     while (!executorService.isTerminated())


### PR DESCRIPTION
Must happen outside the loop but with a condition that it has not happened yet as the exception in the worker thread might have propagated and stopped it already in the catch block.

As discussed in https://github.com/vinted/camus/pull/24/files#r64889614

@vidma @ljank @astrauka 