### PR TITLE
Fetch schemas index in main thread

### DIFF
--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeper.java
@@ -217,6 +217,8 @@ public class CamusSweeper extends Configured implements Tool
       try
       {
         runCollectorForTopicDir(fs, topicName, new Path(topic.getPath(), sourceSubdir), destinationPath);
+        log.info("Shutting down priority executor");
+        executorService.shutdown();
       }
       catch (Exception e)
       {
@@ -225,11 +227,6 @@ public class CamusSweeper extends Configured implements Tool
         executorService.shutdown();
         throw e;
       }
-    }
-
-    if (!executorService.isTerminated()) {
-      log.info("Shutting down priority executor");
-      executorService.shutdown();
     }
 
     while (!executorService.isTerminated())

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeper.java
@@ -15,7 +15,6 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -217,18 +216,16 @@ public class CamusSweeper extends Configured implements Tool
       try
       {
         runCollectorForTopicDir(fs, topicName, new Path(topic.getPath(), sourceSubdir), destinationPath);
-        log.info("Shutting down priority executor");
-        executorService.shutdown();
       }
       catch (Exception e)
       {
         System.err.println("unable to process " + topicName + " skipping...");
         e.printStackTrace();
-        executorService.shutdown();
-        throw e;
       }
     }
 
+    log.info("Shutting down priority executor");
+    executorService.shutdown();
     while (!executorService.isTerminated())
     {
       executorService.awaitTermination(30, TimeUnit.SECONDS);
@@ -277,18 +274,8 @@ public class CamusSweeper extends Configured implements Tool
 
     List<Properties> jobPropsList = planner.createSweeperJobProps(topic, topicSourceDir, topicDestDir, fs);
 
-    for (Properties jobProps : jobPropsList) {
+    for (Properties jobProps : jobPropsList){
       tasksToComplete.add(runCollector(jobProps, topic));
-    }
-
-    for (Future<?> task : tasksToComplete) {
-      try {
-        task.get();
-      } catch (InterruptedException e) {
-        throw e;
-      } catch (ExecutionException e) {
-        throw e;
-      }
     }
 
     log.info("Finishing processing for topic " + topic);


### PR DESCRIPTION
Previous attempts to collect exceptions from `Future`s proved to be difficult to manage and keep Sweeper parallel. Instead, lets simplify and fetch schema index once in the main thread before workers start.

In case of failure fails with:

```
16/06/27 11:19:39 INFO sweeper.CamusSweeper: Starting kafka sweeper
16/06/27 11:19:39 INFO sweeper.CamusSweeper: Checking schema-registry connectivity
Exception in thread "main" org.apache.http.conn.HttpHostConnectException: Connection to http://localhost:9292 refused
        at org.apache.http.impl.conn.DefaultClientConnectionOperator.openConnection(DefaultClientConnectionOperator.java:190)
        at org.apache.http.impl.conn.ManagedClientConnectionImpl.open(ManagedClientConnectionImpl.java:294)
        at org.apache.http.impl.client.DefaultRequestDirector.tryConnect(DefaultRequestDirector.java:643)
        at org.apache.http.impl.client.DefaultRequestDirector.execute(DefaultRequestDirector.java:479)
        at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:906)
        at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:805)
        at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:784)
        at com.linkedin.camus.sweeper.CamusSweeper.getResponse(CamusSweeper.java:663)
        at com.linkedin.camus.sweeper.CamusSweeper.testSchemaRegistryConnectivity(CamusSweeper.java:653)
        at com.linkedin.camus.sweeper.CamusSweeper.run(CamusSweeper.java:171)
        at com.linkedin.camus.sweeper.CamusSweeper.run(CamusSweeper.java:643)
        at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:70)
        at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:84)
        at com.linkedin.camus.sweeper.CamusSweeper.main(CamusSweeper.java:669)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.hadoop.util.RunJar.run(RunJar.java:221)
        at org.apache.hadoop.util.RunJar.main(RunJar.java:136)
Caused by: java.net.ConnectException: Connection refused
        at java.net.PlainSocketImpl.socketConnect(Native Method)
        at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
        at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
        at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
        at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
        at java.net.Socket.connect(Socket.java:589)
        at org.apache.http.conn.scheme.PlainSocketFactory.connectSocket(PlainSocketFactory.java:127)
        at org.apache.http.impl.conn.DefaultClientConnectionOperator.openConnection(DefaultClientConnectionOperator.java:180)
        ... 19 more
```

@ljank @vidma @astrauka 