### PR TITLE
Add schema registry connectivity checkt to camus etl

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
@@ -71,6 +71,8 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormatter;
 
+import com.vinted.camus.schemaregistry.ConnectivityCheck;
+
 public class CamusJob extends Configured implements Tool {
 
 	public static final String ETL_EXECUTION_BASE_PATH = "etl.execution.base.path";
@@ -95,6 +97,9 @@ public class CamusJob extends Configured implements Tool {
 	public static final String KAFKA_HOST_PORT = "kafka.host.port";
 	public static final String KAFKA_TIMEOUT_VALUE = "kafka.timeout.value";
 	public static final String LOG4J_CONFIGURATION = "log4j.configuration";
+  public static final String SCHEMA_REGISTRY_HOST = "camus.etl.schema.registry.host";
+  public static final String SCHEMA_REGISTRY_ENDPOINT = "camus.etl.schema.registry.endpoint";
+  public static final String SCHEMA_REGISTRY_CONNECTIVITY_CHECK = "camus.etl.schema.registry.connectivity.check";
 	private static org.apache.log4j.Logger log;
 
 	private final Properties props;
@@ -233,7 +238,16 @@ public class CamusJob extends Configured implements Tool {
 		Job job = createJob(props);
 		if (getLog4jConfigure(job)) {
 			DOMConfigurator.configure("log4j.xml");
-		}
+    }
+
+    if (Boolean.parseBoolean(props.getProperty(SCHEMA_REGISTRY_CONNECTIVITY_CHECK))) {
+      log.info("Checking schema-registry connectivity");
+      String schemaRegistryHost = (String) props.getProperty(SCHEMA_REGISTRY_HOST);
+      String schemaRegistryEndpoint = (String) props.getProperty(SCHEMA_REGISTRY_ENDPOINT);
+      URI schemaIndexAddress = new URI(schemaRegistryHost + schemaRegistryEndpoint);
+      ConnectivityCheck.check(schemaIndexAddress);
+    }
+
 		FileSystem fs = FileSystem.get(job.getConfiguration());
 
 		log.info("Dir Destination set to: "

--- a/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/CamusJobTest.java
+++ b/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/CamusJobTest.java
@@ -97,6 +97,7 @@ public class CamusJobTest {
         props.setProperty(EtlMultiOutputFormat.ETL_DESTINATION_PATH, destinationPath);
         props.setProperty(CamusJob.ETL_EXECUTION_BASE_PATH, path + EXECUTION_BASE_PATH);
         props.setProperty(CamusJob.ETL_EXECUTION_HISTORY_PATH, path + EXECUTION_HISTORY_PATH);
+        props.setProperty(CamusJob.SCHEMA_REGISTRY_CONNECTIVITY_CHECK, "false");
 
         props.setProperty(EtlInputFormat.CAMUS_MESSAGE_DECODER_CLASS, JsonStringMessageDecoder.class.getName());
         props.setProperty(EtlMultiOutputFormat.ETL_RECORD_WRITER_PROVIDER_CLASS,

--- a/camus-schema-registry/src/main/java/com/vinted/camus/ConnectivityCheck.java
+++ b/camus-schema-registry/src/main/java/com/vinted/camus/ConnectivityCheck.java
@@ -1,0 +1,30 @@
+package com.vinted.camus.schemaregistry;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.client.methods.HttpGet;
+
+
+public class ConnectivityCheck {
+    private static final Integer HTTP_SUCCESS_CODE = 200;
+
+    public static void check(URI schemaIndexAddress) throws Exception
+    {
+        HttpResponse indexResponse = getResponse(schemaIndexAddress);
+
+        assert(indexResponse.getStatusLine().getStatusCode() == HTTP_SUCCESS_CODE);
+    }
+
+    private static HttpResponse getResponse(URI schemaIndexAddress) throws IOException
+    {
+        DefaultHttpClient httpClient = new DefaultHttpClient();
+
+        HttpGet requestMethod = new HttpGet(schemaIndexAddress);
+        return httpClient.execute(requestMethod);
+    }
+
+}

--- a/camus-sweeper/pom.xml
+++ b/camus-sweeper/pom.xml
@@ -17,6 +17,10 @@
     </properties>
 
     <dependencies>
+      <dependency>
+        <groupId>com.linkedin.camus</groupId>
+        <artifactId>camus-schema-registry</artifactId>
+      </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>


### PR DESCRIPTION
Extracted common checking code to `camus-schema-registry` and reused in both in `camus-etl` and `camus-sweeper`.

@ljank @astrauka @vidma 