### PR TITLE
Add camus schema registry to sweeper artifact set

### DIFF
--- a/camus-sweeper/pom.xml
+++ b/camus-sweeper/pom.xml
@@ -108,6 +108,7 @@
                                     <include>org.kitesdk:*</include>
                                     <include>com.codahale.metrics:*</include>
                                     <include>com.typesafe:*</include>
+                                    <include>com.linkedin.camus:camus-schema-registry:*</include>
                                 </includes>
                             </artifactSet>
                         </configuration>


### PR DESCRIPTION
Otherwise ConnectivityCheck of https://github.com/vinted/camus/pull/28 will not be included in the resulting JAR.

@astrauka 