### PR TITLE
Make camus deployable to GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ target
 **/.idea
 .idea
 **/dependency-reduced-pom.xml
+.auth_token
 
 # target dirs
 camus-api/target/

--- a/camus-api/pom.xml
+++ b/camus-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>${camus.version}</version>
   </parent>
 
   <artifactId>camus-api</artifactId>

--- a/camus-etl-kafka/pom.xml
+++ b/camus-etl-kafka/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.linkedin.camus</groupId>
 		<artifactId>camus-parent</artifactId>
-		<version>0.1.0-SNAPSHOT</version>
+		<version>${camus.version}</version>
 	</parent>
 
 	<artifactId>camus-etl-kafka</artifactId>

--- a/camus-example/pom.xml
+++ b/camus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>${camus.version}</version>
   </parent>
 
   <artifactId>camus-example</artifactId>

--- a/camus-kafka-coders/pom.xml
+++ b/camus-kafka-coders/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.linkedin.camus</groupId>
 		<artifactId>camus-parent</artifactId>
-		<version>0.1.0-SNAPSHOT</version>
+		<version>${camus.version}</version>
 	</parent>
 
 	<artifactId>camus-kafka-coders</artifactId>

--- a/camus-schema-registry-avro/pom.xml
+++ b/camus-schema-registry-avro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>${camus.version}</version>
   </parent>
 
   <artifactId>camus-schema-registry-avro</artifactId>

--- a/camus-schema-registry/pom.xml
+++ b/camus-schema-registry/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>${camus.version}</version>
   </parent>
 
   <artifactId>camus-schema-registry</artifactId>

--- a/camus-sweeper/pom.xml
+++ b/camus-sweeper/pom.xml
@@ -4,12 +4,12 @@
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-sweeper</artifactId>
     <name>Camus compaction code small files produced Camus</name>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>${camus.version}</version>
 
     <parent>
         <groupId>com.linkedin.camus</groupId>
         <artifactId>camus-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${camus.version}</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 			<dependency>
 				<groupId>org.apache.hadoop</groupId>
 				<artifactId>hadoop-client</artifactId>
-				<version>2.3.0-mr1-cdh5.1.0</version>
+				<version>2.6.0-mr1-cdh5.7.0</version>
 			</dependency>
 			<dependency>
                 <groupId>org.apache.kafka</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>com.linkedin.camus</groupId>
 	<artifactId>camus-parent</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>${camus.version}</version>
 	<packaging>pom</packaging>
 	<name>Camus Parent</name>
 	<description>
@@ -26,32 +26,32 @@
 			<dependency>
 				<groupId>com.linkedin.camus</groupId>
 				<artifactId>camus-api</artifactId>
-				<version>0.1.0-SNAPSHOT</version>
+				<version>${camus.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.linkedin.camus</groupId>
 				<artifactId>camus-etl-kafka</artifactId>
-				<version>0.1.0-SNAPSHOT</version>
+				<version>${camus.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.linkedin.camus</groupId>
 				<artifactId>camus-kafka-coders</artifactId>
-				<version>0.1.0-SNAPSHOT</version>
+				<version>${camus.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.linkedin.camus</groupId>
 				<artifactId>camus-schema-registry</artifactId>
-				<version>0.1.0-SNAPSHOT</version>
+				<version>${camus.version}</version>
 			</dependency>
-            <dependency>
-				<groupId>com.linkedin.camus</groupId>
-                <artifactId>camus-schema-registry-avro</artifactId>
-                <version>0.1.0-SNAPSHOT</version>
-            </dependency>
-			<dependency>
-				<groupId>com.linkedin.camus</groupId>
+      <dependency>
+        <groupId>com.linkedin.camus</groupId>
+        <artifactId>camus-schema-registry-avro</artifactId>
+        <version>${camus.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.linkedin.camus</groupId>
 				<artifactId>camus-schema-registry</artifactId>
-				<version>0.1.0-SNAPSHOT</version>
+				<version>${camus.version}</version>
 				<type>test-jar</type>
 				<scope>test</scope>
 			</dependency>

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+AUTH_TOKEN_FILE=".auth_token"
+PROJECT="vinted/camus"
+
+if [ -f $AUTH_TOKEN_FILE ];
+then
+   oauth_key=`cat $AUTH_TOKEN_FILE`
+else
+   read -r -p "Did not find '$AUTH_TOKEN_FILE'. Please provide your GitHub OAuth key (create here https://github.com/settings/tokens): " oauth_key
+fi
+
+echo "Currently available release tags:"
+
+release_list_json=$(curl -s -H "Content-Type: application/json" -H "Authorization: token $oauth_key" https://api.github.com/repos/$PROJECT/releases)
+
+ruby -rjson -e 'puts JSON.parse(ARGV[0]).map { |rev| "* " + rev["tag_name"] }.join("\n")' "$release_list_json"
+
+read -r -p "Please provide a new release tag name: " tag_name
+
+echo "Building Camus release $tag_name"
+
+mvn clean package -Dcamus.version=$tag_name
+
+echo "Tagging Camus release $tag_name"
+
+release_body=$(cat << EOF
+{
+    "tag_name": "$tag_name",
+    "target_commitish": "master",
+    "name": "v$tag_name",
+    "body": "Vinted Camus release $tag_name",
+    "draft": false,
+    "prerelease": false
+}
+EOF
+)
+
+release_create_json=$(curl -s -H "Content-Type: application/json" -H "Authorization: token $oauth_key" -X POST -d "$release_body" https://api.github.com/repos/${PROJECT}/releases)
+release_id=$(ruby -rjson -e 'puts JSON.parse(ARGV[0])["id"]' "$release_create_json")
+
+echo "Uploading Camus ETL jar for $tag_name"
+
+camus_etl_file="camus-etl-kafka-$tag_name-shaded.jar"
+
+curl -s -H "Content-Type: application/zip" -H "Authorization: token $oauth_key" -X POST --data "@camus-etl-kafka/target/$camus_etl_file" https://uploads.github.com/repos/${PROJECT}/releases/$release_id/assets?name=$camus_etl_file > /dev/null 2>&1
+
+echo "Uploading Camus Sweeper jar for $tag_name"
+
+camus_sweeper_file="camus-sweeper-$tag_name.jar"
+
+curl -s -H "Content-Type: application/zip" -H "Authorization: token $oauth_key" -X POST --data "@camus-sweeper/target/$camus_sweeper_file" https://uploads.github.com/repos/${PROJECT}/releases/$release_id/assets?name=$camus_sweeper_file > /dev/null 2>&1


### PR DESCRIPTION
This makes Camus artefacts deployable to Github, see my dummy repo for an example: https://github.com/saulius/dummytestrepo/releases. We can download them when deploying instead of S3/Hadoop/custom maven repo alternative.

The flow looks like this:

```
$ ./release.sh
Currently available release tags:
* 1.0.0
Please provide a new release tag name: 1.0.1
Building Camus release 1.0.1
<— camus build noise —>
Tagging Camus release 1.0.1
Uploading Camus ETL jar for 1.0.1
Uploading Camus Sweeper jar for 1.0.1
$
```

@astrauka @vidma @ljank 