### PR TITLE
Add job ID to failure message

### DIFF
--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeper.java
@@ -439,8 +439,8 @@ public class CamusSweeper extends Configured implements Tool
 
       if (!job.isSuccessful())
       {
-        System.err.println("hadoop job failed");
-        throw new RuntimeException("hadoop job failed.");
+        System.err.println("Hadoop job " + job.getJobID() + " failed");
+        throw new RuntimeException("Hadoop job " + job.getJobID() + " failed");
       }
 
       Path oldPath = null;


### PR DESCRIPTION
Otherwise it's hard to pin-point reason of the failure.

Here's what we see in stderr for failed camus job:

```
Error occurred in event.user.click-993600c2-a130-40a2-b2ec-f41025eacb04 at hdfs://warehouse:8020/etl/events-kafka-lt-multi-dc/destination/event.user.click/etl/2017/03/02 message hadoop job failed.
java.lang.RuntimeException: hadoop job failed.
```

In order to find the real error, we have to know job ID that was processing that particular `user.click` event. I was able to do that by looking for `event.user.click-993600c2-a130-40a2-b2ec-f41025eacb04` occurrence — this wasn't very convenient and took some time to find this path. I've also wasted some additional time, because I was blind to `user.click` mention — it seemed like the whole job failed due to unknown reason, whereas failure was caused due to very specific event.

After this change it'll be (a little more) obvious where to look for the real error.

@vinted/sre 